### PR TITLE
Correct README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let chords = scribble.clip({
 	sizzle: true
 });  
 
-scribble.render(chords, 'chords.mid');
+scribble.midi(chords, 'chords.mid');
 ```
 
 I imported that into Garage Band and applied Synthesize -> EDM Chord ->Sunrise Chords to it and here is how it sounds:


### PR DESCRIPTION
'scribble.render' should be 'scribble.midi'

Signed-off-by: Yishuang Lu <eason.lu@turn.com>