### PR TITLE
update engine spec to >6.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "url": "https://github.com/walmik/scribbletune/issues"
   },
   "engines": {
-    "node": "6.x.x"
+    "node": ">6.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribbletune",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Create music with JavaScript and Node.js!",
   "main": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
Hi Walmik,
Today I saw the video https://www.youtube.com/watch?v=iwuZzp_ZnLo of your talk demonstrating scribbletune at the SFNode meet up, and I was totally blown away. This is amazing! I wanted to try it out immediately, so I tried installing it on my system. Much to my dismay, I was unable to install it, since it is locked to node v6.x.x and I am running v7.7.2. This makes me very sad.

I forked the repo. Lo and behold, the tests pass on v7.7.2! So, here is a PR to enable scribbletune to work on more recent versions of node.