### PR TITLE
Ensure octave type number in mode function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribbletune",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Create music with JavaScript and Node.js!",
   "main": "./src/index.js",
   "scripts": {

--- a/src/mode.js
+++ b/src/mode.js
@@ -15,7 +15,7 @@ const chromaticNotes = ['c', 'c#', 'd', 'd#', 'e', 'f', 'f#', 'g', 'g#', 'a', 'a
 const mode = (root, mode, octave, addRootFromNextOctave) => {
 	root = root || 'c';
 	mode = mode || 'ionian';
-	octave = octave || 3;
+	octave = octave ? Number(octave) : 3;
 	addRootFromNextOctave = addRootFromNextOctave === false ? false : true;
 	// Make sure the root is valid [abcdefg] optionally followed by #
 	assert(root.match(/[abcdefg]#?/i), 'Invalid root note: ' + root);

--- a/test/chord.js
+++ b/test/chord.js
@@ -94,6 +94,13 @@ test('Scribbletune::chord', t => {
 		'c4,e4,g4,a#4',
 		'C Augmented is C E G A#'
 	);
+
+	t.equal(
+		scribble.chord('fmin5').join(),
+		'f5,g#5,c6',
+		'F minor is F, G#, C'
+	);
+
 	t.end();
 });
 


### PR DESCRIPTION
Incorrect output when increasing the octave due to string concatenation.

E.g. `scribble.chord('fmin5')` => [ 'f5', 'g#5', 'c51' ]

